### PR TITLE
project/add/: start arrow icon animation, on date selection via material

### DIFF
--- a/zyt-app/src/app/project/add-project/add-project.component.html
+++ b/zyt-app/src/app/project/add-project/add-project.component.html
@@ -37,7 +37,7 @@
     
     <mat-form-field>
       <label for="end">Deadline</label>
-      <input matInput [matDatepicker]="end"  name="end" ngDefaultControl [(ngModel)]="endDate" required (change)="checkFormForButton()">
+      <input matInput [matDatepicker]="end"  name="end" ngDefaultControl [(ngModel)]="endDate" required (ngModelChange)="checkFormForButton()">
       <span id="nameError" class="input-error-message" aria-live="polite">Deadline is invalid</span>
       <mat-datepicker-toggle matSuffix [for]="end"></mat-datepicker-toggle>
       <mat-datepicker #end></mat-datepicker>


### PR DESCRIPTION
animation now starts after date was chosen via material date picker. 
before, it did only trigger the animation if the date was chosen without 
the date picker.